### PR TITLE
Open-pr-long-running-branch

### DIFF
--- a/components/note-editor.stories.tsx
+++ b/components/note-editor.stories.tsx
@@ -4,7 +4,8 @@ import NoteEditor from "./note-editor";
 const meta = {
   component: NoteEditor,
   args: {
-    initialTitle: 'This title has changed and PR is closed',
+    //open-pr-long-running-branch
+    initialTitle: 'This title is changed from the long running branch and still open',
     initialBody: 'This is a body',
     noteId: 1,
   }


### PR DESCRIPTION
This branch was created before pr-closed-title-changed-again was closed.

We should be able to run again the workflow against the new references (in branch : pr-closed-title-changed-again)